### PR TITLE
Parse $SSH_ORIGINAL_COMMAND via xargs

### DIFF
--- a/sshcommand
+++ b/sshcommand
@@ -39,7 +39,7 @@ case "$1" in
 
     KEY=$(cat)
     FINGERPRINT=$(ssh-keygen -lf /dev/stdin <<< $(echo $KEY) | awk '{print $2}')
-    KEY_PREFIX="command=\"FINGERPRINT=$FINGERPRINT NAME=$NAME \`cat $USERHOME/.sshcommand\` \$SSH_ORIGINAL_COMMAND\",no-agent-forwarding,no-user-rc,no-X11-forwarding,no-port-forwarding"
+    KEY_PREFIX="command=\"FINGERPRINT=$FINGERPRINT NAME=$NAME xargs \`cat $USERHOME/.sshcommand\` <<<\\\"\$SSH_ORIGINAL_COMMAND\\\"\",no-agent-forwarding,no-user-rc,no-X11-forwarding,no-port-forwarding"
     echo "$KEY_PREFIX $KEY" >> "$USERHOME/.ssh/authorized_keys"
     echo $FINGERPRINT
     ;;


### PR DESCRIPTION
I'm not terribly well-versed in Bash, but if I'm not mistaken, the unquoted version allows users to do something like this to execute arbitrary commands:

`ssh dokku@progriumapps.com "version; rm -rf /"`

whereas the quoted version triggers some kind of escaping logic that prevents that from happening.