### PR TITLE
Only add SSH key if it doesn't already exists

### DIFF
--- a/sshcommand
+++ b/sshcommand
@@ -58,6 +58,13 @@ case "$1" in
 
     getent passwd "$USER" > /dev/null || false
     USERHOME=$(sh -c "echo ~$USER")
+
+    NEW_KEY=$(grep "NAME=\\\\\"$NAME"\\\\\" "$USERHOME/.ssh/authorized_keys" || true)
+    if [ ! -z "$NEW_KEY" ]; then
+      echo "Duplicate SSH Key name" >&2
+      exit -1
+    fi
+
     KEY_FILE=$(mktemp)
     KEY=$(tee "$KEY_FILE")
     delete_key_file() {
@@ -70,6 +77,7 @@ case "$1" in
       echo "Invalid ssh public key"
       exit -1
     fi
+
     KEY_PREFIX="command=\"FINGERPRINT=$FINGERPRINT NAME=\\\"$NAME\\\" \`cat $USERHOME/.sshcommand\` \$SSH_ORIGINAL_COMMAND\",no-agent-forwarding,no-user-rc,no-X11-forwarding,no-port-forwarding"
     echo "$KEY_PREFIX $KEY" >> "$USERHOME/.ssh/authorized_keys"
     echo "$FINGERPRINT"

--- a/tests/unit/core.bats
+++ b/tests/unit/core.bats
@@ -74,6 +74,19 @@ check_authorized_keys_entry() {
   check_authorized_keys_entry $TEST_KEY_NAME 'broken user'
 }
 
+@test "(core) sshcommand acl-add (duplicate key)" {
+  run bash -c "cat ${TEST_KEY_DIR}/${TEST_KEY_NAME}.pub | sshcommand acl-add $TEST_USER user1"
+  echo "output: "$output
+  echo "status: "$status
+
+  run bash -c "cat ${TEST_KEY_DIR}/${TEST_KEY_NAME}.pub | sshcommand acl-add $TEST_USER user1"
+  echo "output: "$output
+  echo "status: "$status
+
+  assert_failure
+  check_authorized_keys_entry $TEST_KEY_NAME user1
+}
+
 @test "(core) sshcommand acl-remove" {
   run bash -c "cat ${TEST_KEY_DIR}/${TEST_KEY_NAME}.pub | sshcommand acl-add $TEST_USER user1"
   echo "output: "$output


### PR DESCRIPTION
I'm not sure if `exit 1` is the right choice here. We might consider exiting more silently.

Fixes #14