### PR TITLE
match Debian* in f_adduser()

### DIFF
--- a/sshcommand
+++ b/sshcommand
@@ -16,7 +16,7 @@ f_adduser() {
   l_user=$1
   l_platform="$(f_print_os_name)"
   case $l_platform in
-    Debian|Ubuntu)
+    Debian*|Ubuntu)
       adduser --disabled-password --gecos "" "$l_user"
       ;;
     *)


### PR DESCRIPTION
currently `make test-in-docker` fails because `Debian GNU/Linux` doesn't match case statement
```
make test-in-docker
docker run -ti --rm -v /Users/mhobbs/src/external/dokku/sshcommand:/app -w /app --hostname='box223' sshcommand_test make ci-dependencies install test
make: Nothing to be done for 'ci-dependencies'.
setting up...
cp ./sshcommand /usr/local/bin
chmod +x /usr/local/bin
linting...
running unit tests...
 ✗ (core) sshcommand create
   (from function `create_user' in file tests/unit/test_helper.bash, line 97,
    from function `setup' in test file tests/unit/core.bats, line 6)
     `create_user' failed with status 9
   groupadd: group 'sshcommand_user' already exists
   Looking for files to backup/remove ...
   Removing files ...
   Removing user `sshcommand_user' ...
   Warning: group `sshcommand_user' has no more members.
   Done.
...
```
```
root@box223:/app# sshcommand create sshcommand_user ls
groupadd: group 'sshcommand_user' already exists
root@box223:/app# sed -n 's#^NAME="\(.*\)"#\1#p' /etc/os-release
Debian GNU/Linux
```
ref: https://github.com/dokku/sshcommand/pull/18#discussion_r48094058
