### PR TITLE
Add support for Debian-based Raspian OS

### DIFF
--- a/sshcommand
+++ b/sshcommand
@@ -16,7 +16,7 @@ f_adduser() {
   l_user=$1
   l_platform="$(f_print_os_name)"
   case $l_platform in
-    Debian*|Ubuntu)
+    Debian*|Ubuntu|Raspbian*)
       adduser --disabled-password --gecos "" "$l_user"
       ;;
     *)


### PR DESCRIPTION
Totally at your discretion, but this was necessary to have sshcommand work as intended on the Raspian, the OS for the Raspberry Pi.

Maybe there is a better overarching method to detect debian-based systems?