### PR TITLE
Add the ability to specify the key_file as an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ssh ls@server <your-args>
 
 ```shell
 sshcommand create     <USER> <COMMAND>          # Creates a user forced to run command when SSH connects
-sshcommand acl-add    <USER> <NAME>             # Adds named SSH key to user from STDIN or argument
+sshcommand acl-add    <USER> <NAME> <KEY_FILE>  # Adds named SSH key to user from STDIN or argument
 sshcommand acl-remove <USER> <NAME>             # Removes SSH key by name
 sshcommand help       <COMMAND>                 # Shows help information
 ```
@@ -32,6 +32,10 @@ On a server, create a new command user:
 On your computer, add authorized keys with your key:
 
     $ cat ~/.ssh/id_rsa.pub | ssh root@server sshcommand acl-add cmd progrium
+
+If the public key is already on the server, you may also specify it as an argument:
+
+    $ ssh root@server sshcommand acl-add cmd progrium ~/.ssh/id_rsa.pub
 
 Now anywhere with the private key you can easily run:
 

--- a/sshcommand
+++ b/sshcommand
@@ -102,7 +102,7 @@ sshcommand-create() {
 
 sshcommand-acl-add() {
   declare desc="Adds named SSH key to user from STDIN or argument"
-  declare USER="$1" NAME="$2"
+  declare USER="$1" NAME="$2" KEY_FILE="$3"
   local FINGERPRINT KEY KEY_FILE KEY_PREFIX NEW_KEY USERHOME
 
   if [[ -z "$USER" ]] || [[ -z "$NAME" ]]; then
@@ -117,12 +117,14 @@ sshcommand-acl-add() {
     log-fail "Duplicate SSH Key name"
   fi
 
-  KEY_FILE=$(mktemp)
-  KEY=$(tee "$KEY_FILE")
-  delete_key_file() {
-    rm -f "$KEY_FILE"
-  }
-  trap delete_key_file INT EXIT
+  if [[ -z "$KEY_FILE" ]]; then
+    KEY_FILE=$(mktemp)
+    KEY=$(tee "$KEY_FILE")
+    trap 'rm -f "$KEY_FILE"' INT EXIT
+  else
+    KEY=$(cat "$KEY_FILE")
+  fi
+
   FINGERPRINT=$(ssh-keygen -lf "$KEY_FILE" | awk '{print $2}')
 
   if [[ ! "$FINGERPRINT" =~ :.* ]]; then

--- a/tests/unit/core.bats
+++ b/tests/unit/core.bats
@@ -58,6 +58,22 @@ check_authorized_keys_entry() {
   check_authorized_keys_entry new_key user2
 }
 
+@test "(core) sshcommand acl-add (as argument)" {
+  run bash -c "sshcommand acl-add $TEST_USER user1 ${TEST_KEY_DIR}/${TEST_KEY_NAME}.pub"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  create_test_key new_key
+  run bash -c "sshcommand acl-add $TEST_USER user2 ${TEST_KEY_DIR}/new_key.pub"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  check_authorized_keys_entry $TEST_KEY_NAME user1
+  check_authorized_keys_entry new_key user2
+}
+
 @test "(core) sshcommand acl-add (bad key failure)" {
   run bash -c "echo test_key | sshcommand acl-add $TEST_USER user1"
   echo "output: "$output


### PR DESCRIPTION
This allows setups where /dev/stdin is not available (some docker installations) to work as expected.