### PR TITLE
Add support for alpine linux 3.x. Closes #16

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,8 +2,9 @@ FROM gcc:latest
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
 
+RUN apt-get update && apt-get install -qq -y software-properties-common sudo
+
 ADD . /app
 WORKDIR /app
 
-RUN apt-get update && apt-get install -qq -y software-properties-common sudo
 RUN make -e ci-dependencies

--- a/sshcommand
+++ b/sshcommand
@@ -46,7 +46,11 @@ fn-info() {
 fn-print-os-id() {
   declare desc="Returns the release id of the operating system"
   local OSRELEASE="${SSHCOMMAND_OSRELEASE:="/etc/os-release"}"
-  sed -n 's#^ID=\(.*\)#\1#p' "$OSRELEASE"
+  if [[ -f $OSRELEASE ]]; then
+    sed -n 's#^ID=\(.*\)#\1#p' "$OSRELEASE"
+  else
+    echo unknown
+  fi
   return 0
 }
 

--- a/sshcommand
+++ b/sshcommand
@@ -7,9 +7,6 @@ if [[ -f /etc/defaults/sshcommand ]]; then
   source /etc/defaults/sshcommand
 fi
 
-readonly ALLOWED_KEYS="${SSHCOMMAND_ALLOWED_KEYS:="no-agent-forwarding,no-user-rc,no-X11-forwarding,no-port-forwarding"}"
-readonly OSRELEASE="${SSHCOMMAND_OSRELEASE:="/etc/os-release"}"
-
 cmd-help() {
   declare desc="Shows help information for a command"
   declare args="$*"
@@ -48,6 +45,7 @@ fn-info() {
 
 fn-print-os-name() {
   declare desc="Returns the release name of the operating system"
+  local OSRELEASE="${SSHCOMMAND_OSRELEASE:="/etc/os-release"}"
   sed -n 's#^NAME="\(.*\)"#\1#p' "$OSRELEASE" | sed 's/./\L&/g'
   return 0
 }
@@ -108,7 +106,7 @@ sshcommand-create() {
 sshcommand-acl-add() {
   declare desc="Adds named SSH key to user from STDIN or argument"
   declare USER="$1" NAME="$2" KEY_FILE="$3"
-  local FINGERPRINT KEY KEY_FILE KEY_PREFIX NEW_KEY USERHOME
+  local ALLOWED_KEYS FINGERPRINT KEY KEY_FILE KEY_PREFIX NEW_KEY USERHOME
 
   if [[ -z "$USER" ]] || [[ -z "$NAME" ]]; then
     log-fail "Usage: sshcommand acl-add" "$(fn-args "sshcommand-acl-add")"
@@ -136,6 +134,7 @@ sshcommand-acl-add() {
     log-fail "Invalid ssh public key"
   fi
 
+  ALLOWED_KEYS="${SSHCOMMAND_ALLOWED_KEYS:="no-agent-forwarding,no-user-rc,no-X11-forwarding,no-port-forwarding"}"
   KEY_PREFIX="command=\"FINGERPRINT=$FINGERPRINT NAME=\\\"$NAME\\\" \`cat $USERHOME/.sshcommand\` \$SSH_ORIGINAL_COMMAND\",$ALLOWED_KEYS"
   echo "$KEY_PREFIX $KEY" >> "$USERHOME/.ssh/authorized_keys"
   echo "$FINGERPRINT"

--- a/sshcommand
+++ b/sshcommand
@@ -188,4 +188,6 @@ main() {
   fi
 }
 
-main "$@"
+if [[ "$0" == "$BASH_SOURCE" ]]; then
+  main "$@"
+fi

--- a/sshcommand
+++ b/sshcommand
@@ -43,10 +43,10 @@ fn-info() {
   fi
 }
 
-fn-print-os-name() {
-  declare desc="Returns the release name of the operating system"
+fn-print-os-id() {
+  declare desc="Returns the release id of the operating system"
   local OSRELEASE="${SSHCOMMAND_OSRELEASE:="/etc/os-release"}"
-  sed -n 's#^NAME="\(.*\)"#\1#p' "$OSRELEASE" | sed 's/./\L&/g'
+  sed -n 's#^ID=\(.*\)#\1#p' "$OSRELEASE"
   return 0
 }
 
@@ -55,7 +55,7 @@ fn-adduser() {
   local l_user l_platform
 
   l_user=$1
-  l_platform="$(fn-print-os-name)"
+  l_platform="$(fn-print-os-id)"
   case $l_platform in
     debian*|ubuntu|raspbian*)
       adduser --disabled-password --gecos "" "$l_user"

--- a/sshcommand
+++ b/sshcommand
@@ -61,6 +61,10 @@ fn-adduser() {
   l_user=$1
   l_platform="$(fn-print-os-id)"
   case $l_platform in
+    alpine)
+      adduser -D -g "" -s /bin/bash "$l_user"
+      passwd -u "$l_user"
+      ;;
     debian*|ubuntu|raspbian*)
       adduser --disabled-password --gecos "" "$l_user"
       ;;

--- a/tests/unit/fixtures/alpine-32-os-release
+++ b/tests/unit/fixtures/alpine-32-os-release
@@ -1,0 +1,6 @@
+NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.2.3
+PRETTY_NAME="Alpine Linux v3.2"
+HOME_URL="http://alpinelinux.org"
+BUG_REPORT_URL="http://bugs.alpinelinux.org"

--- a/tests/unit/fixtures/debian-jessie-os-release
+++ b/tests/unit/fixtures/debian-jessie-os-release
@@ -1,0 +1,7 @@
+PRETTY_NAME="Debian GNU/Linux jessie/sid"
+NAME="Debian GNU/Linux"
+ID=debian
+ANSI_COLOR="1;31"
+HOME_URL="http://www.debian.org/"
+SUPPORT_URL="http://www.debian.org/support/"
+BUG_REPORT_URL="http://bugs.debian.org/"

--- a/tests/unit/fixtures/ubuntu-1404-os-release
+++ b/tests/unit/fixtures/ubuntu-1404-os-release
@@ -1,0 +1,9 @@
+NAME="Ubuntu"
+VERSION="14.04.3 LTS, Trusty Tahr"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 14.04.3 LTS"
+VERSION_ID="14.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"

--- a/tests/unit/functions.bats
+++ b/tests/unit/functions.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "(fn) print-os-id (custom path)" {
+  load "/usr/local/bin/sshcommand"
+
+  SSHCOMMAND_OSRELEASE=$BATS_TEST_DIRNAME/fixtures/ubuntu-1404-os-release run "fn-print-os-id"
+  echo "output: "$output
+  echo "status: "$status
+  assert_output "ubuntu"
+  assert_success
+
+  SSHCOMMAND_OSRELEASE=$BATS_TEST_DIRNAME/fixtures/debian-jessie-os-release run "fn-print-os-id"
+  echo "output: "$output
+  echo "status: "$status
+  assert_output "debian"
+  assert_success
+
+  SSHCOMMAND_OSRELEASE=$BATS_TEST_DIRNAME/fixtures/alpine-32-os-release run "fn-print-os-id"
+  echo "output: "$output
+  echo "status: "$status
+  assert_output "alpine"
+  assert_success
+}

--- a/tests/unit/functions.bats
+++ b/tests/unit/functions.bats
@@ -23,3 +23,12 @@ load test_helper
   assert_output "alpine"
   assert_success
 }
+
+@test "(fn) print-os-id (invalid path)" {
+  load "/usr/local/bin/sshcommand"
+  SSHCOMMAND_OSRELEASE=/tmp/nonexistent-os-release run "fn-print-os-id"
+  echo "output: "$output
+  echo "status: "$status
+  assert_output "unknown"
+  assert_success
+}


### PR DESCRIPTION
Alpine Linux 3.x uses different flags for the `adduser` call. Specifically, the following map to their debian counterparts:

- -D: `--disabled-password`
- -g: `--gecos`
- -s: login shell (none by default)

We also need to set the password to none manually.

I also took the liberty of making a few other related changes to allow better flexibility in testing.

Closes #16.