### PR TITLE
Add sshcommand-list, update help

### DIFF
--- a/sshcommand
+++ b/sshcommand
@@ -90,7 +90,7 @@ log-verbose() {
 }
 
 sshcommand-create() {
-  declare desc="Creates a user forced to run command when SSH connects"
+  declare desc="Creates a local system user and installs sshcommand skeleton"
   declare USER="$1" COMMAND="$2"
   local USERHOME
 
@@ -163,6 +163,19 @@ sshcommand-acl-remove() {
   sed --in-place "/ NAME=\\\\\"$NAME\\\\\" /d" "$USERHOME/.ssh/authorized_keys"
 }
 
+sshcommand-list() {
+  declare desc="Lists SSH user keys by name"
+  declare userhome USER="$1"
+  [[ -z "$USER" ]] && log-fail "Usage: sshcommand list" "$(fn-args "sshcommand-list")"
+
+  getent passwd "$USER" > /dev/null || log-fail "\"$USER\" is not a user on this system"
+  userhome=$(sh -c "echo ~$USER")
+  [[ -e "$userhome/.ssh/authorized_keys" ]] || log-fail "authorized_keys not found for $USER"
+  [[ -s "$userhome/.ssh/authorized_keys" ]] || log-fail "authorized_keys is empty for $USER"
+  grep -oE '[a-f0-9]{2}(:[a-f0-9]{2}){15}\ NAME=\\".*\\"|SSH_ORIGINAL_COMMAND\",[a-zA-Z0-9,\-]*' "$userhome/.ssh/authorized_keys" | \
+    sed -e 's/\\//g' -e 's/SSH_ORIGINAL_COMMAND",/ SSHCOMMAND_ALLOWED_KEYS: /g'
+}
+
 sshcommand-help() {
   declare desc="Shows help information"
   declare COMMAND="$1"
@@ -174,10 +187,11 @@ sshcommand-help() {
 
   echo "sshcommand"
   echo ""
-  printf "  %-10s %-26s %s\n" "create"     "$(fn-args "sshcommand-create")"     "$(fn-desc "sshcommand-create")"
-  printf "  %-10s %-26s %s\n" "acl-add"    "$(fn-args "sshcommand-acl-add")"    "$(fn-desc "sshcommand-acl-add")"
-  printf "  %-10s %-26s %s\n" "acl-remove" "$(fn-args "sshcommand-acl-remove")" "$(fn-desc "sshcommand-acl-remove")"
-  printf "  %-10s %-26s %s\n" "help"       "$(fn-args "sshcommand-help")"       "$(fn-desc "sshcommand-help")"
+  printf "  %-10s %-30s %s\n" "create"     "$(fn-args "sshcommand-create")"     "$(fn-desc "sshcommand-create")"
+  printf "  %-10s %-30s %s\n" "acl-add"    "$(fn-args "sshcommand-acl-add")"    "$(fn-desc "sshcommand-acl-add")"
+  printf "  %-10s %-30s %s\n" "acl-remove" "$(fn-args "sshcommand-acl-remove")" "$(fn-desc "sshcommand-acl-remove")"
+  printf "  %-10s %-30s %s\n" "list"       "$(fn-args "sshcommand-list")"       "$(fn-desc "sshcommand-list")"
+  printf "  %-10s %-30s %s\n" "help"       "$(fn-args "sshcommand-help")"       "$(fn-desc "sshcommand-help")"
 }
 
 main() {

--- a/tests/unit/core.bats
+++ b/tests/unit/core.bats
@@ -153,9 +153,26 @@ check_custom_allowed_keys() {
   assert_failure
 }
 
+@test "(core) sshcommand list" {
+  run bash -c "cat ${TEST_KEY_DIR}/${TEST_KEY_NAME}.pub | sshcommand acl-add $TEST_USER user1"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run bash -c "sshcommand list ${TEST_USER} | grep $(ssh-keygen -l -f /home/${TEST_USER}/.ssh/authorized_keys | grep -oE '[a-f0-9]{2}(:[a-f0-9]{2}){15}')"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run bash -c "sshcommand acl-remove $TEST_USER user1 && sshcommand list"
+  echo "output: "$output
+  echo "status: "$status
+  assert_failure
+}
+
 @test "(core) sshcommand help" {
   run bash -c "sshcommand help | wc -l"
   echo "output: "$output
   echo "status: "$status
-  [[ "$output" -ge 4 ]]
+  [[ "$output" -ge 7 ]]
 }


### PR DESCRIPTION
Adds ability to list keys and users added by `sshcommand acl-add`.

Output example:
```
$ sshcommand list dokku
17:88:a4:f3:1b:6f:cb:3c:00:92:99:f0:73:6d:e7:af NAME="test"
 SSHCOMMAND_ALLOWED_KEYS: no-agent-forwarding,no-user-rc,no-X11-forwarding,no-port-forwarding
9c:08:e3:97:f6:4c:9d:1c:5a:5a:09:78:7e:d1:83:2b NAME="user1"
 SSHCOMMAND_ALLOWED_KEYS: no-agent-forwarding,no-user-rc,no-X11-forwarding,no-port-forwarding
```