### PR TITLE
Fixed failing unit test for sshcommand list

### DIFF
--- a/tests/unit/core.bats
+++ b/tests/unit/core.bats
@@ -159,7 +159,7 @@ check_custom_allowed_keys() {
   echo "status: "$status
   assert_success
 
-  run bash -c "sshcommand list ${TEST_USER} | grep $(ssh-keygen -l -f /home/${TEST_USER}/.ssh/authorized_keys | grep -oE '[a-f0-9]{2}(:[a-f0-9]{2}){15}')"
+  run bash -c "sshcommand list ${TEST_USER} | grep $(ssh-keygen -l -f /home/${TEST_USER}/.ssh/authorized_keys | awk '{print $2}')"
   echo "output: "$output
   echo "status: "$status
   assert_success


### PR DESCRIPTION
If you run `make test-in-docker` on a fresh Docker install, it will fail:

```console
...
setting up...
cp ./sshcommand /usr/local/bin
chmod +x /usr/local/bin
linting...
# SC2034: VAR appears unused - https://github.com/koalaman/shellcheck/wiki/SC2034
# desc is used to declare the description of the function
running unit tests...
 ✓ (core) sshcommand create
 ✓ (core) sshcommand acl-add
 ✓ (core) sshcommand acl-add (as argument)
 ✓ (core) sshcommand acl-add (custom allowed keys)
 ✓ (core) sshcommand acl-add (bad key failure)
 ✓ (core) sshcommand acl-add (with identifier space)
 ✓ (core) sshcommand acl-add (duplicate key)
 ✓ (core) sshcommand acl-remove
 ✗ (core) sshcommand list
   (from function `flunk' in file tests/unit/test_helper.bash, line 14,
    from function `assert_success' in file tests/unit/test_helper.bash, line 21,
    in test file tests/unit/core.bats, line 165)
     `assert_success' failed
   output: 84:1b:0d:f3:21:82:0c:63:bf:d7:e5:bb:82:9c:5f:59
   status: 0
   output: 84:1b:0d:f3:21:82:0c:63:bf:d7:e5:bb:82:9c:5f:59 NAME="user1" bash: line 1: 84:1b:0d:f3:21:82:0c:63:bf:d7:e5:bb:82:9c:5f:59: command not found
   status: 127
   command failed with exit status 127
   Looking for files to backup/remove ...
   Removing files ...
   Removing user `sshcommand_user' ...
   Warning: group `sshcommand_user' has no more members.
   Done.
 ✓ (core) sshcommand help
 ✓ (fn) print-os-id (custom path)
 ✓ (fn) print-os-id (invalid path)

12 tests, 1 failure
Makefile:40: recipe for target 'unit-tests' failed
make: *** [unit-tests] Error 1
make: *** [test-in-docker] Error 2
```

At first I was thinking that it's because you didn't pin to a certain base Docker image (using `:latest` is a bad practice and **will** punish at some point). I then tested on gcc:5.3.0 and gcc:5.2.0 and it was all the same error. (I tested on two different Docker hosts with Ubuntu and OS X).

I traced the problem to `ssh-keygen -l -f .ssh/authorized_keys` probably returning not what the script expected. The current output in the testing environment is:

```console
# ssh-keygen -l -f /home/${TEST_USER}/.ssh/authorized_keys
2048 fb:58:39:ef:c1:c5:d2:0c:99:40:51:cf:c3:a3:c9:ad command="FINGERPRINT=fb:58:39:ef:c1:c5:d2:0c:99:40:51:cf:c3:a3:c9:ad NAME=\"user1\" `cat /home/sshcommand_user/.sshcommand` $SSH_ORIGINAL_COMMAND",no-agent-forwarding,no-user-rc,no-X11-forwarding,no-port-forwarding (RSA)
```

When processed by `| grep ...` it returns the fingerprint twice, thus crashing the subsequent script flow. The PR fixes this by replacing grep with awk.