### PR TITLE
Pinned base Docker image

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM gcc:latest
+FROM gcc:6.1
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
 


### PR DESCRIPTION
Using `:latest` tags is a bad practice, as things eventually will break all of a sudden when a shiny new incompatible base image comes out.