### PR TITLE
Only allow one key per file in acl-add

### DIFF
--- a/sshcommand
+++ b/sshcommand
@@ -136,6 +136,10 @@ sshcommand-acl-add() {
     KEY=$(cat "$KEY_FILE")
   fi
 
+  local count
+  count="$(wc -l <<< "$KEY")"
+  [[ "$count" -eq 1 ]] || log-fail "Too many keys provided, set one per invocation of sshcommand acl-add <USER> <NAME>"
+
   FINGERPRINT=$(ssh-keygen -lf "$KEY_FILE" | awk '{print $2}')
 
   if [[ ! "$FINGERPRINT" =~ :.* ]]; then

--- a/tests/unit/core.bats
+++ b/tests/unit/core.bats
@@ -118,6 +118,14 @@ check_custom_allowed_keys() {
   check_authorized_keys_entry $TEST_KEY_NAME 'broken user'
 }
 
+@test "(core) sshcommand acl-add (multiple keys)" {
+  create_test_key second_key
+  run bash -c "cat ${TEST_KEY_DIR}/${TEST_KEY_NAME}.pub ${TEST_KEY_DIR}/second_key.pub | sshcommand acl-add $TEST_USER user1"
+  echo "output: "$output
+  echo "status: "$status
+  assert_failure
+}
+
 @test "(core) sshcommand acl-add (duplicate key)" {
   run bash -c "cat ${TEST_KEY_DIR}/${TEST_KEY_NAME}.pub | sshcommand acl-add $TEST_USER user1"
   echo "output: "$output


### PR DESCRIPTION
Otherwise, the additional keys get added without the sshcommand wrapper.