### PR TITLE
chore: drop support for raspbian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,6 @@ release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bullseye build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bookworm build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/trixie build/deb/$(NAME)_$(VERSION)_all.deb
-	package_cloud push $(PACKAGECLOUD_REPOSITORY)/raspbian/bullseye build/deb/$(NAME)_$(VERSION)_all.deb
 
 validate: test
 	mkdir -p validation

--- a/sshcommand
+++ b/sshcommand
@@ -71,7 +71,7 @@ fn-adduser() {
       adduser -D -g "" -s /bin/bash "$l_user"
       passwd -u "$l_user"
       ;;
-    debian* | ubuntu | raspbian*)
+    debian* | ubuntu)
       adduser --disabled-password --gecos "" "$l_user"
       ;;
     arch | amzn)


### PR DESCRIPTION
Raspbian is a Debian derivative and is already covered by the published Debian packages, so the dedicated raspbian PackageCloud repository is redundant. This stops publishing raspbian packages and drops the raspbian runtime special-case.

Closes #284
