### PR TITLE
feat: publish packages for ubuntu 26.04 resolute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ release-packagecloud:
 release-packagecloud-deb: build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/jammy build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/noble build/deb/$(NAME)_$(VERSION)_all.deb
+	package_cloud push $(PACKAGECLOUD_REPOSITORY)/ubuntu/resolute build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bullseye build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/bookworm build/deb/$(NAME)_$(VERSION)_all.deb
 	package_cloud push $(PACKAGECLOUD_REPOSITORY)/debian/trixie build/deb/$(NAME)_$(VERSION)_all.deb

--- a/tests/unit/fixtures/os/ubuntu-2604-os-release
+++ b/tests/unit/fixtures/os/ubuntu-2604-os-release
@@ -1,0 +1,11 @@
+NAME="Ubuntu"
+VERSION="26.04 LTS (Resolute Raccoon)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 26.04 LTS"
+VERSION_ID="26.04"
+VERSION_CODENAME=resolute
+UBUNTU_CODENAME=resolute
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"

--- a/tests/unit/functions.bats
+++ b/tests/unit/functions.bats
@@ -11,6 +11,12 @@ load test_helper
   assert_output "ubuntu"
   assert_success
 
+  SSHCOMMAND_OSRELEASE=$BATS_TEST_DIRNAME/fixtures/os/ubuntu-2604-os-release run "fn-print-os-id"
+  echo "output: $output"
+  echo "status: $status"
+  assert_output "ubuntu"
+  assert_success
+
   SSHCOMMAND_OSRELEASE=$BATS_TEST_DIRNAME/fixtures/os/debian-jessie-os-release run "fn-print-os-id"
   echo "output: $output"
   echo "status: $status"


### PR DESCRIPTION
Ubuntu 26.04 LTS ("Resolute Raccoon", codename `resolute`) hosts had no PackageCloud channel to install from because the release target only pushed to `ubuntu/jammy` and `ubuntu/noble`. This adds an `ubuntu/resolute` push so the next release publishes packages for it as well.

Closes #287. Ref dokku/dokku#8768.