### PR TITLE
chore(deps): bump json from 2.15.2.1 to 2.21.2 in /.github

### DIFF
--- a/.github/Gemfile.lock
+++ b/.github/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
     http-cookie (1.1.0)
       domain_name (~> 0.5)
     insist (1.0.0)
-    json (2.15.2.1)
+    json (2.21.2)
     logger (1.7.0)
     mime-types (3.7.0)
       logger


### PR DESCRIPTION
Resolves Dependabot alert 9 (GHSA-x2f5-4prf-w687 / CVE-2026-54696), a low-severity heap buffer overflow in the `json` gem. The flaw is a heap out-of-bounds write in the IO-streaming generator path (`JSON.dump(obj, io)` and `JSON::State#generate(obj, io)`) when a streamed string sits near the 16 KB internal buffer boundary, with a demonstrated impact of a denial-of-service crash. The vulnerable range is `>= 2.9.0, < 2.19.9` and the first patched release is `2.19.9`.

In this repository `json` is a transitive dependency of `package_cloud`, which together with `fpm` is used only by the CI release tooling that builds and publishes the Debian package, so it is not part of the runtime of the shipped `sshcommand` script. This bumps the locked version to the latest 2.x release, `2.21.2`, which resolves the advisory while continuing to satisfy the existing `json (~> 2.9)` constraint.
